### PR TITLE
EpochSys::Init()

### DIFF
--- a/src/TestConfig.cpp
+++ b/src/TestConfig.cpp
@@ -418,7 +418,7 @@ void GlobalTestConfig::buildAffinity(std::vector<hwloc_obj_t>& aff){
 		buildDefaultAffinity(aff);
 	}
 	// extendAffinity() shoud be called to cover oversubscription.
-	assert(aff.size() >= task_num);
+	assert(aff.size() >= (uint64_t)task_num);
 }
 
 

--- a/src/persist/EpochSys.cpp
+++ b/src/persist/EpochSys.cpp
@@ -653,141 +653,12 @@ namespace pds{
         global_epoch->store(max_epoch);
         // set system mode back to online
         sys_mode = ONLINE;
-        reset();
+
+        // we postpone reset until init()
 
         std::cout<<"returning from EpochSys Recovery."<<std::endl;
 #endif /* !MNEMOSYNE */
         return in_use;
-    }
-
-    void nbEpochSys::reset(){
-        EpochSys::reset();
-        // TODO: only nbEpochSys needs persistent descs. consider move all
-        // inits into nbEpochSys.
-        for (int i = 0; i < gtc->task_num; i++) {
-            to_be_persisted->init_desc_local(local_descs[i], i);
-        }
-    }
-
-    void nbEpochSys::parse_env(){
-        if (epoch_advancer){
-            delete epoch_advancer;
-        }
-        if (trans_tracker){
-            delete trans_tracker;
-        }
-        if (to_be_persisted) {
-            delete to_be_persisted;
-        }
-        if (to_be_freed) {
-            delete to_be_freed;
-        }
-
-        if (!gtc->checkEnv("EpochLengthUnit")){
-            gtc->setEnv("EpochLengthUnit", "Millisecond");
-        }
-
-        if (!gtc->checkEnv("EpochLength")){
-            gtc->setEnv("EpochLength", "50");
-        }
-
-        if (!gtc->checkEnv("BufferSize")){
-            gtc->setEnv("BufferSize", "64");
-        }
-
-        if (gtc->checkEnv("PersistStrat")){
-            if (gtc->getEnv("PersistStrat") == "No"){
-                to_be_persisted = new NoToBePersistContainer();
-                to_be_freed = new NoToBeFreedContainer(this);
-                epoch_advancer = new NoEpochAdvancer();
-                trans_tracker = new NoTransactionTracker(this->global_epoch);
-                persisted_epochs = new IncreasingMindicator(task_num);
-                return;
-            }
-        }
-
-        if (gtc->checkEnv("PersistStrat")){
-            string env_persist = gtc->getEnv("PersistStrat");
-            if (env_persist == "DirWB"){
-                to_be_persisted = new DirWB(_ral, gtc->task_num);
-            } else if (env_persist == "PerEpoch"){
-                errexit("nbEpochSys isn't compatible with PerEpoch!");
-            } else if (env_persist == "BufferedWB"){
-                to_be_persisted = new BufferedWB(gtc, _ral);
-            } else {
-                errexit("unrecognized 'persist' environment");
-            }
-        } else {
-            gtc->setEnv("PersistStrat", "BufferedWB");
-            to_be_persisted = new BufferedWB(gtc, _ral);
-        }
-
-        if (gtc->checkEnv("Free")){
-            string env_free = gtc->getEnv("Free");
-            if (env_free == "PerEpoch"){
-                to_be_freed = new PerEpochFreedContainer(this, gtc);
-            } else if (env_free == "No"){
-                to_be_freed = new NoToBeFreedContainer(this);
-            } else {
-                errexit("unrecognized 'free' environment");
-            }
-        } else {
-            to_be_freed = new PerEpochFreedContainer(this, gtc);
-        }
-
-        if (gtc->checkEnv("TransTracker")){
-            string env_transcounter = gtc->getEnv("TransTracker");
-            if (env_transcounter == "AtomicCounter"){
-                trans_tracker = new AtomicTransactionTracker(this->global_epoch);
-            } else if (env_transcounter == "ActiveThread"){
-                trans_tracker = new FenceBeginTransactionTracker(this->global_epoch, task_num);
-            } else if (env_transcounter == "CurrEpoch"){
-                trans_tracker = new PerEpochTransactionTracker(this->global_epoch, task_num);
-            } else {
-                errexit("unrecognized 'transaction counter' environment");
-            }
-        } else {
-            trans_tracker = new PerEpochTransactionTracker(this->global_epoch, task_num);
-        }
-
-        if (gtc->checkEnv("PersistTracker")){
-            string env_persisttracker = gtc->getEnv("PersistTracker");
-            if (env_persisttracker == "IncreasingMindicator"){
-                persisted_epochs = new IncreasingMindicator(task_num);
-            } else if (env_persisttracker == "Mindicator"){
-                persisted_epochs = new Mindicator(task_num);
-            } else {
-                errexit("unrecognized 'persist tracker' environment");
-            }
-        } else {
-            persisted_epochs = new IncreasingMindicator(task_num);
-        }
-
-        epoch_advancer = new DedicatedEpochAdvancerNbSync(gtc, this);
-
-        // if (gtc->checkEnv("EpochAdvance")){
-        //     string env_epochadvance = gtc->getEnv("EpochAdvance");
-        //     if (env_epochadvance == "Global"){
-        //         epoch_advancer = new GlobalCounterEpochAdvancer();
-        //     } else if (env_epochadvance == "SingleThread"){
-        //         epoch_advancer = new SingleThreadEpochAdvancer(gtc);
-        //     } else if (env_epochadvance == "Dedicated"){
-        //         epoch_advancer = new DedicatedEpochAdvancer(gtc, this);
-        //     } else {
-        //         errexit("unrecognized 'epoch advance' argument");
-        //     }
-        // } else {
-        //     gtc->setEnv("EpochAdvance", "Dedicated");
-        //     epoch_advancer = new DedicatedEpochAdvancer(gtc, this);
-        // }
-
-        // if (gtc->checkEnv("EpochFreq")){
-        //     int env_epoch_advance = stoi(gtc->getEnv("EpochFreq"));
-        //     if (gtc->getEnv("EpochAdvance") != "Dedicated" && env_epoch_advance > 63){
-        //         errexit("invalid EpochFreq power");
-        //     }
-        //     epoch_advancer->set_epoch_freq(env_epoch_advance);
-        // }
     }
 
     void nbEpochSys::register_alloc_pblk(PBlk* b, uint64_t c){
@@ -1054,6 +925,10 @@ namespace pds{
                         uint64_t curr_tid = tmp->get_tid();
                         max_tid_local = std::max(max_tid_local, curr_tid);
                         descs_local[curr_tid] = tmp;
+                        if(curr_tid<(uint64_t)task_num) {
+                            assert(local_descs[curr_tid]==nullptr);
+                            local_descs[curr_tid] = tmp;
+                        }
                     } else if (curr_blk->blktype == DELETE) {
                         anti_nodes_local.push_back(curr_blk);
                         if (curr_blk->get_epoch() != NULL_EPOCH){
@@ -1183,9 +1058,7 @@ namespace pds{
                             } break;
                             case DELETE:
                             case EPOCH:
-                                break;
                             case DESC:
-                                not_in_use_local.push_back(curr_blk);
                                 break;
                             default:
                                 errexit("wrong type of pblk discovered");
@@ -1229,7 +1102,8 @@ namespace pds{
 
         // set system mode back to online
         sys_mode = ONLINE;
-        reset();
+
+        // we postpone reset until init()
 
         std::cout << "returning from EpochSys Recovery." << std::endl;
 #endif /* !MNEMOSYNE */

--- a/src/persist/EpochSys.hpp
+++ b/src/persist/EpochSys.hpp
@@ -388,38 +388,14 @@ public:
     // system mode that toggles on/off PDELETE for recovery purpose.
     SysMode sys_mode = ONLINE;
 
-    EpochSys(GlobalTestConfig* _gtc) : uid_generator(_gtc->task_num), gtc(_gtc) {
+    EpochSys(GlobalTestConfig* _gtc) : uid_generator(_gtc->task_num), gtc(_gtc), task_num(_gtc->task_num) {
         std::string heap_name = get_ralloc_heap_name();
         // task_num+1 to construct Ralloc for dedicated epoch advancer
         _ral = new Ralloc(_gtc->task_num+1,heap_name.c_str(),REGION_SIZE);
-        local_descs = new sc_desc_t* [gtc->task_num];
+        local_descs = new sc_desc_t* [gtc->task_num] {nullptr};
         last_epochs = new padded<uint64_t>[_gtc->task_num];
-        // [wentao] FIXME: this may need to change if recovery reuses
-        // existing descs
-        bool restart=_ral->is_restart();
-        if (restart) {
-            int rec_thd = _gtc->task_num;
-            if (_gtc->checkEnv("RecoverThread")){
-                rec_thd = stoi(_gtc->getEnv("RecoverThread"));
-            }
-            auto begin = chrono::high_resolution_clock::now();
-            recovered = recover(rec_thd);
-            auto end = chrono::high_resolution_clock::now();
-            auto dur = end - begin;
-            auto dur_ms = std::chrono::duration_cast<std::chrono::milliseconds>(dur).count();
-            std::cout << "Spent " << dur_ms << "ms getting PBlk(" << recovered->size() << ")" << std::endl;
-        }
-        for(int i=0;i<gtc->task_num;i++){
-            local_descs[i] = new_pblk<sc_desc_t>(i);
-            last_epochs[i].ui = NULL_EPOCH;
-            assert(local_descs[i]!=nullptr);
-            persist_func::clwb_range_nofence(local_descs[i],sizeof(sc_desc_t));
-        }
-        persist_func::sfence();
-        if (!restart) {
-            reset();
-        }
-        
+        // desc allocation and potential recovery are all in init()
+
     }
 
     // void flush(){
@@ -455,10 +431,12 @@ public:
         _ral->set_fake_dirty();
         delete _ral;
         delete last_epochs;
+        if(recovered)
+            delete recovered;
         // std::cout<<"Aborted:Total = "<<abort_cnt.load()<<":"<<total_cnt.load()<<std::endl;
     }
 
-    virtual void parse_env();
+    void parse_env();
 
     std::string get_ralloc_heap_name(){
         if (!gtc->checkEnv("HeapName")){
@@ -478,8 +456,7 @@ public:
         return ret;
     }
 
-    virtual void reset(){
-        task_num = gtc->task_num;
+    void reset(){
         if (!epoch_container){
             epoch_container = new_pblk<Epoch>();
             epoch_container->blktype = EPOCH;
@@ -644,7 +621,30 @@ public:
     /////////////
     // Recover //
     /////////////
-    
+    virtual void init() {
+        bool restart=_ral->is_restart();
+        if (restart) {
+            int rec_thd = gtc->task_num;
+            if (gtc->checkEnv("RecoverThread")){
+                rec_thd = stoi(gtc->getEnv("RecoverThread"));
+            }
+            auto begin = chrono::high_resolution_clock::now();
+            recovered = recover(rec_thd);
+            auto end = chrono::high_resolution_clock::now();
+            auto dur = end - begin;
+            auto dur_ms = std::chrono::duration_cast<std::chrono::milliseconds>(dur).count();
+            std::cout << "Spent " << dur_ms << "ms getting PBlk(" << recovered->size() << ")" << std::endl;
+        }
+        for(int i=0;i<gtc->task_num;i++){
+            assert(local_descs[i]==nullptr);
+            local_descs[i] = new_pblk<sc_desc_t>(i);
+            last_epochs[i].ui = NULL_EPOCH;
+            assert(local_descs[i]!=nullptr);
+            persist_func::clwb_range_nofence(local_descs[i],sizeof(sc_desc_t));
+        }
+        reset();
+    }
+
     std::unordered_map<uint64_t, PBlk*>* get_recovered() {
         return (recovered);
     }
@@ -660,8 +660,39 @@ class nbEpochSys : public EpochSys {
     // starts in epoch c; this must contain only reset payloads
     void local_persist(uint64_t c);
    public:
-    virtual void reset() override;
-    virtual void parse_env() override;
+    virtual void init() override {
+        bool restart=_ral->is_restart();
+        if (restart) {
+            int rec_thd = gtc->task_num;
+            if (gtc->checkEnv("RecoverThread")){
+                rec_thd = stoi(gtc->getEnv("RecoverThread"));
+            }
+            auto begin = chrono::high_resolution_clock::now();
+            recovered = recover(rec_thd);
+            auto end = chrono::high_resolution_clock::now();
+            auto dur = end - begin;
+            auto dur_ms = std::chrono::duration_cast<std::chrono::milliseconds>(dur).count();
+            std::cout << "Spent " << dur_ms << "ms getting PBlk(" << recovered->size() << ")" << std::endl;
+        }
+        bool reached_all_reused_descs = false; // for debugging
+        for(int i=0;i<gtc->task_num;i++){
+            assert(!reached_all_reused_descs || local_descs[i]==nullptr);
+            if(local_descs[i]==nullptr){
+                reached_all_reused_descs=true;
+                local_descs[i] = new_pblk<sc_desc_t>(i);
+                last_epochs[i].ui = NULL_EPOCH;
+            } else {
+                // this is already a reused desc
+                last_epochs[i].ui = local_descs[i]->epoch;
+            }
+            assert(local_descs[i]!=nullptr);
+            persist_func::clwb_range_nofence(local_descs[i],sizeof(sc_desc_t));
+        }
+        reset();
+        for (int i = 0; i < gtc->task_num; i++) {
+            to_be_persisted->init_desc_local(local_descs[i], i);
+        }
+    }
     virtual uint64_t begin_transaction() override;
     virtual void end_transaction(uint64_t c) override;
     virtual uint64_t begin_reclaim_transaction() override;

--- a/src/persist/api/Recoverable.cpp
+++ b/src/persist/api/Recoverable.cpp
@@ -28,7 +28,8 @@ Recoverable::Recoverable(GlobalTestConfig* gtc){
         gtc->setEnv("Liveness", "Blocking");
         _esys = new pds::EpochSys(gtc);
     }
-    auto recovered_pblks = _esys->get_recovered();
+    _esys->init();
+    recovered_pblks = _esys->get_recovered();
     if (recovered_pblks) {
         last_recovered_cnt = recovered_pblks->size();
     }
@@ -38,10 +39,7 @@ Recoverable::~Recoverable(){
     delete pending_allocs;
     delete pending_retires;
     delete epochs;
-    if (recovered_pblks) {
-        delete recovered_pblks;
-    }
-    Persistent::finalize();
+    // Persistent::finalize();
 }
 void Recoverable::init_thread(GlobalTestConfig*, LocalTestConfig* ltc){
     pds::EpochSys::init_thread(ltc->tid);

--- a/src/rideables/MontageHashTable.hpp
+++ b/src/rideables/MontageHashTable.hpp
@@ -33,7 +33,7 @@ public:
         ListNode(MontageHashTable* ds_, K key, V val): ds(ds_){
             payload = ds->pnew<Payload>(key, val);
         }
-        ListNode(Payload* _payload) : payload(_payload) {} // for recovery
+        ListNode(MontageHashTable* ds_, Payload* _payload) : ds(ds_), payload(_payload) {} // for recovery
         K get_key(){
             assert(payload!=nullptr && "payload shouldn't be null");
             // old-see-new never happens for locking ds
@@ -235,7 +235,7 @@ public:
                                   HWLOC_CPUBIND_THREAD);
                 for (size_t i = rec_tid; i < payloadVector.size(); i += rec_thd){
                     //re-insert payload.
-                    ListNode* new_node = new ListNode(payloadVector[i]);
+                    ListNode* new_node = new ListNode(this, payloadVector[i]);
                     K key = new_node->get_key();
                     size_t idx = hash_fn(key) % idxSize;
                     std::lock_guard<std::mutex> lk(buckets[idx].lock);
@@ -267,7 +267,6 @@ public:
         dur = end - begin;
         auto dur_ms_ins = std::chrono::duration_cast<std::chrono::milliseconds>(dur).count();
         std::cout << "Spent " << dur_ms_ins << "ms inserting(" << recovered->size() << ")" << std::endl;
-        delete recovered;
         return rec_cnt;
     }
 };

--- a/src/rideables/MontageLfHashTable.hpp
+++ b/src/rideables/MontageLfHashTable.hpp
@@ -50,7 +50,7 @@ private:
             payload = ds->pnew<Payload>(k,v);
             // assert(ds->epochs[pds::EpochSys::tid].ui == NULL_EPOCH);
             };
-        Node(Payload* _payload) : payload(_payload),key(_payload->get_unsafe_key(ds)) {} // for recovery
+        Node(MontageLfHashTable* ds_, Payload* _payload) : ds(ds_), payload(_payload),key(_payload->get_unsafe_key(ds)) {} // for recovery
         K get_key(){
             return key;
         }
@@ -153,7 +153,7 @@ public:
                                   HWLOC_CPUBIND_THREAD);
                 for (size_t i = rec_tid; i < payloadVector.size(); i += rec_thd) {
                     // re-insert payload.
-                    Node* tmpNode = new Node(payloadVector[i]);
+                    Node* tmpNode = new Node(this, payloadVector[i]);
                     K key = tmpNode->get_key();
                     size_t idx = hash_fn(key) % idxSize;
                     MarkPtr* prev = nullptr;
@@ -185,7 +185,6 @@ public:
         dur = end - begin;
         auto dur_ms_ins = std::chrono::duration_cast<std::chrono::milliseconds>(dur).count();
         std::cout << "Spent " << dur_ms_ins << "ms inserting(" << recovered->size() << ")" << std::endl;
-        delete recovered;
         return rec_cnt;
     }
 

--- a/src/rideables/MontageLfSkipList.hpp
+++ b/src/rideables/MontageLfSkipList.hpp
@@ -250,7 +250,6 @@ public:
         std::cout << "Spent " << dur_ms_ins << "ms inserting(" << recovered->size() << ")" << std::endl;
 
         should_cas_verify.store(true);
-        delete recovered;
         return rec_cnt;
     }
 

--- a/src/tests/RecoverVerifyTest.hpp
+++ b/src/tests/RecoverVerifyTest.hpp
@@ -77,7 +77,6 @@ inline std::string RecoverVerifyTest<std::string,std::string>::fromInt(uint64_t 
 template <class K, class V>
 int RecoverVerifyTest<K,V>::execute(GlobalTestConfig* gtc, LocalTestConfig* ltc){
     std::string value_buffer; // for string kv only
-    gtc->setEnv("HeapName", "RecoveryVerifyTest");
     if (!gtc->checkEnv("NoVerify")){
         if (ltc->tid == 0){ // FIXME: workaround when we can't change the total thread count of ralloc.
             std::unordered_map<K,V> reference;
@@ -130,6 +129,7 @@ int RecoverVerifyTest<K,V>::execute(GlobalTestConfig* gtc, LocalTestConfig* ltc)
                 std::cout<<"rec_cnt currect."<<std::endl;
             } else {
                 std::cout<<"recovered:"<<rec_cnt<<" expecting:"<<reference.size()<<std::endl;
+                std::cout<<"Test FAILED!"<<std::endl;
                 exit(1);
             }
             
@@ -140,6 +140,7 @@ int RecoverVerifyTest<K,V>::execute(GlobalTestConfig* gtc, LocalTestConfig* ltc)
                 }
             }
             std::cout<<"all records recovered."<<std::endl;
+            std::cout<<"Test PASSED!"<<std::endl;
             return ops;
         } else {
             return 0;


### PR DESCRIPTION
* reuse persistent desc and dynamically allocate more for nbEpochSys; for EpochSys, persistent desc is always deallocated during recovery
* always dirty exit; right now we aren't able to snapshot transient indexing to support clean exit.
* move recovery logic from `EpochSys()` to (nb)`EpochSys::init()`, and call `init()` in `Recoverable()`
* move reset to EpochSys::init()
* make reset and parse_env non-virtual func
* pass `this` to newly allocated Node (using payloads) during recovery
* remove `setEnv("HeapName")` in `RecoverVerifyTest::execute()`
* Suppress warning